### PR TITLE
fix(gitlab): support gitlab subgroups

### DIFF
--- a/scripts/label_for_url.py
+++ b/scripts/label_for_url.py
@@ -146,19 +146,7 @@ def determine_label(input_url: str) -> str:
     ):
         return m.group("id")
     elif m := re.search(
-        r"https://[^/]*git(hub|lab)[^/]*/(?P<project>[^/]+)/(?P<repo>[^/#?]+)/?"
-        r"(?:wiki/(?P<wiki_page>[^/#?]+))?"
-        r"(?:#(?P<anchor>[a-z][a-zA-Z0-9_-]+))?"
-        r"(?:\?.*)?"
-        r"$",  # NB: Include $ to not prematurely match any of the next two cases
-        input_url,
-    ):
-        project = f"{m.group('project')}/"
-        wiki_page = f" > {prettify(m.group('wiki_page'))}" if m.group("wiki_page") else ""
-        anchor = f" > {prettify(m.group('anchor'))}" if m.group("anchor") else ""
-        return f"{project}{m.group('repo')}{wiki_page}{anchor}"
-    elif m := re.search(
-        r"^https://[^/]*git(hub|lab)[^/]*/(?P<project>[^/]+)/(?P<repo>[^/]+)(/-)?/("
+        r"^https://[^/]*git(hub|lab)[^/]*/(?P<project>[a-zA-Z\-/]+?)/(?P<repo>[^/]+)(/-)?/("
         r"((?P<type>issues|pull|discussions|merge_requests|pipelines|jobs)/(?P<number>\d+)"
         r"(/diffs\?commit_id=(?P<commit>[a-f0-9]+))?"
         r"(#((issue|discussion)comment-|discussion_r|note_)(?P<comment_id>\d+))?)"
@@ -173,7 +161,7 @@ def determine_label(input_url: str) -> str:
         release_tag = f"@{m.group('release_tag')}" if m.group("release_tag") else ""
         return f"{m.group('project')}/{m.group('repo')}{number}{commit}{comment_id}{release_tag}"
     elif m := re.search(
-        r"^https://[^/]*git(hub|lab)[^/]*/(?P<project>[^/]+)/(?P<repo>[^/]+)(/-)?/"
+        r"^https://[^/]*git(hub|lab)[^/]*/(?P<project>[a-zA-Z\-/]+?)/(?P<repo>[^/]+)(/-)?/"
         r"(?:blob|tree|commit)/(?P<rev>[^/]+)"
         r"(?:/(?P<file>[^#?]+))?"
         r"(?:\?[^#?]+)?"
@@ -199,7 +187,7 @@ def determine_label(input_url: str) -> str:
         return f"{m.group('project')}/{m.group('repo')}{rev}{reference}"
     elif m := re.search(
         r"^https://(?P<host>[^/]*gitlab[^/]*)"
-        r"(/(?P<project>[^/]+)/(?P<repo>[^/]+))?/-/snippets/"
+        r"(/(?P<project>[a-zA-Z\-/]+?)/(?P<repo>[^/]+))?/-/snippets/"
         r"(?P<uid>[^/?#]+)",
         input_url,
     ):
@@ -242,6 +230,18 @@ def determine_label(input_url: str) -> str:
         query_label = f"{','.join(query_labels)}" if query_labels else "🔍"
         separator = "#" if m.group("type") == "issues" else "!"
         return f"{m.group('project')}/{m.group('repo')}{separator}[{query_label}]"
+    elif m := re.search(
+            r"https://[^/]*git(hub|lab)[^/]*/(?P<project>[a-zA-Z\-/]+?)/(?P<repo>[^/#?]+)/?"
+            r"(?:wiki/(?P<wiki_page>[^/#?]+))?"
+            r"(?:#(?P<anchor>[a-z][a-zA-Z0-9_-]+))?"
+            r"(?:\?.*)?"
+            r"$",  # NB: Include $ to not prematurely match any of the next two cases
+            input_url,
+    ):
+        project = f"{m.group('project')}/"
+        wiki_page = f" > {prettify(m.group('wiki_page'))}" if m.group("wiki_page") else ""
+        anchor = f" > {prettify(m.group('anchor'))}" if m.group("anchor") else ""
+        return f"{project}{m.group('repo')}{wiki_page}{anchor}"
     elif m := re.search(
         r"^https://.*jenkins.*/blue/organizations/jenkins/"
         r"(?P<job>[^/]+)"

--- a/scripts/label_for_url.py
+++ b/scripts/label_for_url.py
@@ -146,7 +146,7 @@ def determine_label(input_url: str) -> str:
     ):
         return m.group("id")
     elif m := re.search(
-        r"^https://[^/]*git(hub|lab)[^/]*/(?P<project>[a-zA-Z\-/]+?)/(?P<repo>[^/]+)(/-)?/("
+        r"^https://[^/]*git(hub|lab)[^/]*/(?P<project>[a-zA-Z0-9._/+-]+?)/(?P<repo>[^/]+)(/-)?/("
         r"((?P<type>issues|pull|discussions|merge_requests|pipelines|jobs)/(?P<number>\d+)"
         r"(/diffs\?commit_id=(?P<commit>[a-f0-9]+))?"
         r"(#((issue|discussion)comment-|discussion_r|note_)(?P<comment_id>\d+))?)"
@@ -161,7 +161,7 @@ def determine_label(input_url: str) -> str:
         release_tag = f"@{m.group('release_tag')}" if m.group("release_tag") else ""
         return f"{m.group('project')}/{m.group('repo')}{number}{commit}{comment_id}{release_tag}"
     elif m := re.search(
-        r"^https://[^/]*git(hub|lab)[^/]*/(?P<project>[a-zA-Z\-/]+?)/(?P<repo>[^/]+)(/-)?/"
+        r"^https://[^/]*git(hub|lab)[^/]*/(?P<project>[a-zA-Z0-9._/+-]+?)/(?P<repo>[^/]+)(/-)?/"
         r"(?:blob|tree|commit)/(?P<rev>[^/]+)"
         r"(?:/(?P<file>[^#?]+))?"
         r"(?:\?[^#?]+)?"
@@ -187,7 +187,7 @@ def determine_label(input_url: str) -> str:
         return f"{m.group('project')}/{m.group('repo')}{rev}{reference}"
     elif m := re.search(
         r"^https://(?P<host>[^/]*gitlab[^/]*)"
-        r"(/(?P<project>[a-zA-Z\-/]+?)/(?P<repo>[^/]+))?/-/snippets/"
+        r"(/(?P<project>[a-zA-Z0-9._/+-]+?)/(?P<repo>[^/]+))?/-/snippets/"
         r"(?P<uid>[^/?#]+)",
         input_url,
     ):
@@ -231,12 +231,12 @@ def determine_label(input_url: str) -> str:
         separator = "#" if m.group("type") == "issues" else "!"
         return f"{m.group('project')}/{m.group('repo')}{separator}[{query_label}]"
     elif m := re.search(
-            r"https://[^/]*git(hub|lab)[^/]*/(?P<project>[a-zA-Z\-/]+?)/(?P<repo>[^/#?]+)/?"
-            r"(?:wiki/(?P<wiki_page>[^/#?]+))?"
-            r"(?:#(?P<anchor>[a-z][a-zA-Z0-9_-]+))?"
-            r"(?:\?.*)?"
-            r"$",  # NB: Include $ to not prematurely match any of the next two cases
-            input_url,
+        r"https://[^/]*git(hub|lab)[^/]*/(?P<project>[a-zA-Z\-/]+?)/(?P<repo>[^/#?]+)/?"
+        r"(?:wiki/(?P<wiki_page>[^/#?]+))?"
+        r"(?:#(?P<anchor>[a-z][a-zA-Z0-9_-]+))?"
+        r"(?:\?.*)?"
+        r"$",  # NB: Include $ to not prematurely match any of the next two cases
+        input_url,
     ):
         project = f"{m.group('project')}/"
         wiki_page = f" > {prettify(m.group('wiki_page'))}" if m.group("wiki_page") else ""

--- a/test/test_gitlab.py
+++ b/test/test_gitlab.py
@@ -14,7 +14,8 @@ def test_should_label_repository() -> None:
     # Then:
     assert_that(label).is_equal_to("my-account/some-repo")
 
-def test_should_label_subgroups() -> None:
+
+def test_should_label_repository_in_subgroup() -> None:
     # Given:
     url = "https://gitlab.some.org/my-group/my-subgroup/some-repo"
 

--- a/test/test_gitlab.py
+++ b/test/test_gitlab.py
@@ -14,6 +14,16 @@ def test_should_label_repository() -> None:
     # Then:
     assert_that(label).is_equal_to("my-account/some-repo")
 
+def test_should_label_subgroups() -> None:
+    # Given:
+    url = "https://gitlab.some.org/my-group/my-subgroup/some-repo"
+
+    # When:
+    label = determine_label(url)
+
+    # Then:
+    assert_that(label).is_equal_to("my-group/my-subgroup/some-repo")
+
 
 def test_should_label_repo_and_anchor() -> None:
     # Given:


### PR DESCRIPTION
GitLab allows up to 20 nested subgroups.
Support for subgroups is added by using a lazy project regex.

Unfortunately as a side effect, the regex are not disjoint anymore. This means that the ordering of the regex checks in the if/else-statement matters.