### PR TITLE
Support Jira & Confluence SaaS URLs

### DIFF
--- a/scripts/label_for_url.py
+++ b/scripts/label_for_url.py
@@ -298,6 +298,28 @@ def determine_label(input_url: str) -> str:
         )
         page_id = f"/{m.group('pageId')}" if m.group("pageId") else ""
         return f"{space}{title}{anchor}" or f"{m.group('host')}{page_id}"
+    elif  (
+            m := re.search(
+                r"^https://(?P<org>.*atlassian.*)"
+                r"/wiki/spaces/(?P<space>[^/]+)"
+                r"(?:/pages/(?P<pageId>.*/(?P<title>[^?#]+))?)?"
+                r"\??(?P<args>.*)",
+                input_url,
+            )
+    ):
+        space = m.group("space") if m.group("space") else ""
+        title = f"/{prettify(m.group('title'))}" if m.group("title") else ""
+        args = m.group("args").split("&") # ["focusedCommentId=43245234", "test=abc"]
+
+        args = args[0].split("=") if args[0].startswith("focusedCommentId") else args
+        args = (" > ".join(args) if args[0] == "focusedCommentId" else "")
+        args = (
+            args.replace("focusedCommentId >", " > Comment", 1)
+            if args.startswith("focusedCommentId >")
+            else args
+        )
+        page_id = f"/{m.group('pageId')}" if m.group("pageId") else ""
+        return f"{space}{title}{args}" or f"{m.group('host')}{page_id}"
     elif m := re.search(
         r"^https://(?P<page>\w+\.stackexchange|stackoverflow|askubuntu|serverfault|superuser)\.com/"
         r"(q(uestions)?|a(nswers)?)/(?P<qid>[^/]+)/[^/]+(/(?P<aid>[^/#]+))?",

--- a/scripts/label_for_url.py
+++ b/scripts/label_for_url.py
@@ -298,21 +298,19 @@ def determine_label(input_url: str) -> str:
         )
         page_id = f"/{m.group('pageId')}" if m.group("pageId") else ""
         return f"{space}{title}{anchor}" or f"{m.group('host')}{page_id}"
-    elif  (
-            m := re.search(
-                r"^https://(?P<org>.*atlassian.*)"
-                r"/wiki/spaces/(?P<space>[^/]+)"
-                r"(?:/pages/(?P<pageId>.*/(?P<title>[^?#]+))?)?"
-                r"\??(?P<args>.*)",
-                input_url,
-            )
+    elif m := re.search(
+        r"^https://(?P<org>.*atlassian.*)"
+        r"/wiki/spaces/(?P<space>[^/]+)"
+        r"(?:/pages/(?P<pageId>.*/(?P<title>[^?#]+))?)?"
+        r"\??(?P<args>.*)",
+        input_url,
     ):
         space = m.group("space") if m.group("space") else ""
         title = f"/{prettify(m.group('title'))}" if m.group("title") else ""
-        args = m.group("args").split("&") # ["focusedCommentId=43245234", "test=abc"]
+        args = m.group("args").split("&")  # ["focusedCommentId=43245234", "test=abc"]
 
         args = args[0].split("=") if args[0].startswith("focusedCommentId") else args
-        args = (" > ".join(args) if args[0] == "focusedCommentId" else "")
+        args = " > ".join(args) if args[0] == "focusedCommentId" else ""
         args = (
             args.replace("focusedCommentId >", " > Comment", 1)
             if args.startswith("focusedCommentId >")

--- a/scripts/label_for_url.py
+++ b/scripts/label_for_url.py
@@ -278,7 +278,7 @@ def determine_label(input_url: str) -> str:
         )
     ) or (
         m := re.search(
-            r"^https://(?P<host>.*confluence.*)"
+            r"^https://(?P<host>[^/]*confluence[^/]*)"
             r"/pages/(?:viewpage|releaseview)\.action\?"
             r"(?:spaceKey=(?P<space>[^&#]+))?"
             r"(?:pageId=(?P<pageId>[^&#]+))?"
@@ -299,25 +299,24 @@ def determine_label(input_url: str) -> str:
         page_id = f"/{m.group('pageId')}" if m.group("pageId") else ""
         return f"{space}{title}{anchor}" or f"{m.group('host')}{page_id}"
     elif m := re.search(
-        r"^https://(?P<org>.*atlassian.*)"
-        r"/wiki/spaces/(?P<space>[^/]+)"
-        r"(?:/pages/(?P<pageId>.*/(?P<title>[^?#]+))?)?"
-        r"\??(?P<args>.*)",
+        r"^https://[^/]*atlassian\.(?:com|net)/wiki"
+        r"/spaces/(?P<space>[^/]+)"
+        r"(?:/pages/[0-9]+/(?P<title>[^?#]+))?"
+        r"(?:\?(?P<args>.*))?",
         input_url,
     ):
-        space = m.group("space") if m.group("space") else ""
+        space = m.group("space")
         title = f"/{prettify(m.group('title'))}" if m.group("title") else ""
-        args = m.group("args").split("&")  # ["focusedCommentId=43245234", "test=abc"]
 
-        args = args[0].split("=") if args[0].startswith("focusedCommentId") else args
-        args = " > ".join(args) if args[0] == "focusedCommentId" else ""
-        args = (
-            args.replace("focusedCommentId >", " > Comment", 1)
-            if args.startswith("focusedCommentId >")
-            else args
-        )
-        page_id = f"/{m.group('pageId')}" if m.group("pageId") else ""
-        return f"{space}{title}{args}" or f"{m.group('host')}{page_id}"
+        comment = ""
+        if m.group("args"):
+            args = m.group("args").split("&")  # ["focusedCommentId=43245234", "test=abc"]
+            for key, value in [arg.split("=") for arg in args]:
+                if key == "focusedCommentId":
+                    comment = f" > Comment {value}"
+                    break
+
+        return f"{space}{title}{comment}"
     elif m := re.search(
         r"^https://(?P<page>\w+\.stackexchange|stackoverflow|askubuntu|serverfault|superuser)\.com/"
         r"(q(uestions)?|a(nswers)?)/(?P<qid>[^/]+)/[^/]+(/(?P<aid>[^/#]+))?",

--- a/scripts/label_for_url.py
+++ b/scripts/label_for_url.py
@@ -95,7 +95,7 @@ def determine_label(input_url: str) -> str:
     ):
         return f"🔍/{unquote(m.group('query'))}/"
     elif m := re.search(
-        r"^https://[^/]*jira[^/]*/browse/(?P<project>\w+)(-(?P<issue>\d+))?"
+        r"^https://[^/]*(jira|atlassian)[^/]*/browse/(?P<project>\w+)(-(?P<issue>\d+))?"
         r"(?:\?focused(Comment)?Id=(?P<comment>\d+))?",
         input_url,
     ):
@@ -104,7 +104,7 @@ def determine_label(input_url: str) -> str:
         comment = f".{m.group('comment')}" if m.group("comment") else ""
         return f"{project}{issue}{comment}"
     elif m := re.search(
-        r"^https://[^/]*jira[^/]*/servicedesk/customer/portal/(?P<desk_id>\d+)/(?P<ticket>[\w-]+)",
+        r"^https://[^/]*(jira|atlassian)[^/]*/servicedesk/customer/portal/(?P<desk_id>\d+)/(?P<ticket>[\w-]+)",
         input_url,
     ):
         return f"{m.group('ticket')}"

--- a/test/test_confluence.py
+++ b/test/test_confluence.py
@@ -1,12 +1,12 @@
+import pytest
 from assertpy import assert_that
 
 from label_for_url import determine_label
 
 
-def test_should_label_space() -> None:
-    # Given:
-    url = "https://our-confluence.my-org.de/display/MYSPACE/"
-
+@pytest.mark.parametrize("url", ["https://our-confluence.my-org.de/display/MYSPACE/",
+                                 "https://my-org.atlassian.net/wiki/spaces/MYSPACE/overview"])
+def test_should_label_space(url: str) -> None:
     # When:
     label = determine_label(url)
 
@@ -14,10 +14,9 @@ def test_should_label_space() -> None:
     assert_that(label).is_equal_to("MYSPACE")
 
 
-def test_should_label_url_with_title() -> None:
-    # Given:
-    url = "https://our-confluence.my-org.de/display/MYSPACE/Some+Page+Nobody+Reads"
-
+@pytest.mark.parametrize("url", ["https://our-confluence.my-org.de/display/MYSPACE/Some+Page+Nobody+Reads",
+                                 "https://my-org.atlassian.net/wiki/spaces/MYSPACE/pages/1333624914/Some+Page+Nobody+Reads"])
+def test_should_label_url_with_title(url: str) -> None:
     # When:
     label = determine_label(url)
 
@@ -25,13 +24,13 @@ def test_should_label_url_with_title() -> None:
     assert_that(label).is_equal_to("MYSPACE/Some Page Nobody Reads")
 
 
-def test_should_label_url_with_title_and_comment() -> None:
-    # Given:
-    url = (
-        "https://our-confluence.my-org.de/display/MYSPACE/Some+Page+Nobody+Reads"
-        "?focusedCommentId=241754794#comment-241754794"
-    )
-
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://our-confluence.my-org.de/display/MYSPACE/Some+Page+Nobody+Reads?focusedCommentId=241754794#comment-241754794",
+        "https://my-org.atlassian.net/wiki/spaces/MYSPACE/pages/1333624914/Some+Page+Nobody+Reads?focusedCommentId=241754794"
+    ])
+def test_should_label_url_with_title_and_comment(url: str) -> None:
     # When:
     label = determine_label(url)
 
@@ -39,17 +38,18 @@ def test_should_label_url_with_title_and_comment() -> None:
     assert_that(label).is_equal_to("MYSPACE/Some Page Nobody Reads > Comment 241754794")
 
 
-def test_should_revert_url_encoding() -> None:
-    # Given:
-    url = "https://our-confluence.my-org.de/display/MYSPACE/%5BWIP%5D+Some+Plan+Nobody+Reads"
-
+@pytest.mark.parametrize("url",
+                         ["https://our-confluence.my-org.de/display/MYSPACE/%5BWIP%5D+Some+Page+Nobody+Reads",
+                          "https://my-org.atlassian.net/wiki/spaces/MYSPACE/pages/1333624914/%5BWIP%5D+Some+Page+Nobody+Reads"])
+def test_should_revert_url_encoding(url: str) -> None:
     # When:
     label = determine_label(url)
 
     # Then:
-    assert_that(label).is_equal_to("MYSPACE/[WIP] Some Plan Nobody Reads")
+    assert_that(label).is_equal_to("MYSPACE/[WIP] Some Page Nobody Reads")
 
 
+# TODO: Add test for Confluence cloud variant - not sure yet how the URL looks like
 def test_should_label_url_with_title_in_args_for_viewpage() -> None:
     # Given:
     url = (
@@ -64,6 +64,7 @@ def test_should_label_url_with_title_in_args_for_viewpage() -> None:
     assert_that(label).is_equal_to("MYSPACE/Some Page Nobody Reads")
 
 
+# TODO: Add test for Confluence cloud variant - not sure yet how the URL looks like
 def test_should_label_url_with_title_in_anchor_for_viewpage() -> None:
     # Given:
     url = (
@@ -78,6 +79,7 @@ def test_should_label_url_with_title_in_anchor_for_viewpage() -> None:
     assert_that(label).is_equal_to("SomePage > Säction")
 
 
+# TODO: Add test for Confluence cloud variant - not sure yet how the URL looks like
 def test_should_label_url_with_title_in_args_for_releaseview() -> None:
     # Given:
     url = (
@@ -92,6 +94,7 @@ def test_should_label_url_with_title_in_args_for_releaseview() -> None:
     assert_that(label).is_equal_to("MYSPACE/Some Page Nobody Reads")
 
 
+# TODO: Add test for Confluence cloud variant - not sure yet how the URL looks like
 def test_should_label_url_without_info() -> None:
     # Given:
     url = "https://our-confluence.my-org.de/pages/viewpage.action?pageId=241739726&src=contextnavpagetreemode"

--- a/test/test_confluence.py
+++ b/test/test_confluence.py
@@ -64,7 +64,6 @@ def test_should_revert_url_encoding(url: str) -> None:
     assert_that(label).is_equal_to("MYSPACE/[WIP] Some Page Nobody Reads")
 
 
-# TODO: Add test for Confluence cloud variant - not sure yet how the URL looks like
 def test_should_label_url_with_title_in_args_for_viewpage() -> None:
     # Given:
     url = (

--- a/test/test_confluence.py
+++ b/test/test_confluence.py
@@ -49,16 +49,11 @@ def test_should_label_url_with_title_and_comment(url: str) -> None:
     assert_that(label).is_equal_to("MYSPACE/Some Page Nobody Reads > Comment 241754794")
 
 
-@pytest.mark.parametrize(
-    "url",
-    [
-        "https://our-confluence.my-org.de/display/MYSPACE/%5BWIP%5D+Some+Page+Nobody+Reads",
-        "https://my-org.atlassian.net/wiki/spaces/MYSPACE/pages/1333624914/%5BWIP%5D+Some+Page+Nobody+Reads",
-    ],
-)
-def test_should_revert_url_encoding(url: str) -> None:
+def test_should_revert_url_encoding() -> None:
     # When:
-    label = determine_label(url)
+    label = determine_label(
+        "https://our-confluence.my-org.de/display/MYSPACE/%5BWIP%5D+Some+Page+Nobody+Reads"
+    )
 
     # Then:
     assert_that(label).is_equal_to("MYSPACE/[WIP] Some Page Nobody Reads")

--- a/test/test_confluence.py
+++ b/test/test_confluence.py
@@ -4,8 +4,13 @@ from assertpy import assert_that
 from label_for_url import determine_label
 
 
-@pytest.mark.parametrize("url", ["https://our-confluence.my-org.de/display/MYSPACE/",
-                                 "https://my-org.atlassian.net/wiki/spaces/MYSPACE/overview"])
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://our-confluence.my-org.de/display/MYSPACE/",
+        "https://my-org.atlassian.net/wiki/spaces/MYSPACE/overview",
+    ],
+)
 def test_should_label_space(url: str) -> None:
     # When:
     label = determine_label(url)
@@ -14,8 +19,13 @@ def test_should_label_space(url: str) -> None:
     assert_that(label).is_equal_to("MYSPACE")
 
 
-@pytest.mark.parametrize("url", ["https://our-confluence.my-org.de/display/MYSPACE/Some+Page+Nobody+Reads",
-                                 "https://my-org.atlassian.net/wiki/spaces/MYSPACE/pages/1333624914/Some+Page+Nobody+Reads"])
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://our-confluence.my-org.de/display/MYSPACE/Some+Page+Nobody+Reads",
+        "https://my-org.atlassian.net/wiki/spaces/MYSPACE/pages/1333624914/Some+Page+Nobody+Reads",
+    ],
+)
 def test_should_label_url_with_title(url: str) -> None:
     # When:
     label = determine_label(url)
@@ -28,8 +38,9 @@ def test_should_label_url_with_title(url: str) -> None:
     "url",
     [
         "https://our-confluence.my-org.de/display/MYSPACE/Some+Page+Nobody+Reads?focusedCommentId=241754794#comment-241754794",
-        "https://my-org.atlassian.net/wiki/spaces/MYSPACE/pages/1333624914/Some+Page+Nobody+Reads?focusedCommentId=241754794"
-    ])
+        "https://my-org.atlassian.net/wiki/spaces/MYSPACE/pages/1333624914/Some+Page+Nobody+Reads?focusedCommentId=241754794",
+    ],
+)
 def test_should_label_url_with_title_and_comment(url: str) -> None:
     # When:
     label = determine_label(url)
@@ -38,9 +49,13 @@ def test_should_label_url_with_title_and_comment(url: str) -> None:
     assert_that(label).is_equal_to("MYSPACE/Some Page Nobody Reads > Comment 241754794")
 
 
-@pytest.mark.parametrize("url",
-                         ["https://our-confluence.my-org.de/display/MYSPACE/%5BWIP%5D+Some+Page+Nobody+Reads",
-                          "https://my-org.atlassian.net/wiki/spaces/MYSPACE/pages/1333624914/%5BWIP%5D+Some+Page+Nobody+Reads"])
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://our-confluence.my-org.de/display/MYSPACE/%5BWIP%5D+Some+Page+Nobody+Reads",
+        "https://my-org.atlassian.net/wiki/spaces/MYSPACE/pages/1333624914/%5BWIP%5D+Some+Page+Nobody+Reads",
+    ],
+)
 def test_should_revert_url_encoding(url: str) -> None:
     # When:
     label = determine_label(url)

--- a/test/test_confluence.py
+++ b/test/test_confluence.py
@@ -78,7 +78,6 @@ def test_should_label_url_with_title_in_args_for_viewpage() -> None:
     assert_that(label).is_equal_to("MYSPACE/Some Page Nobody Reads")
 
 
-# TODO: Add test for Confluence cloud variant - not sure yet how the URL looks like
 def test_should_label_url_with_title_in_anchor_for_viewpage() -> None:
     # Given:
     url = (
@@ -93,7 +92,6 @@ def test_should_label_url_with_title_in_anchor_for_viewpage() -> None:
     assert_that(label).is_equal_to("SomePage > Säction")
 
 
-# TODO: Add test for Confluence cloud variant - not sure yet how the URL looks like
 def test_should_label_url_with_title_in_args_for_releaseview() -> None:
     # Given:
     url = (
@@ -108,7 +106,6 @@ def test_should_label_url_with_title_in_args_for_releaseview() -> None:
     assert_that(label).is_equal_to("MYSPACE/Some Page Nobody Reads")
 
 
-# TODO: Add test for Confluence cloud variant - not sure yet how the URL looks like
 def test_should_label_url_without_info() -> None:
     # Given:
     url = "https://our-confluence.my-org.de/pages/viewpage.action?pageId=241739726&src=contextnavpagetreemode"

--- a/test/test_jira.py
+++ b/test/test_jira.py
@@ -3,7 +3,10 @@ from assertpy import assert_that
 
 from label_for_url import determine_label
 
-@pytest.mark.parametrize("url_prefix", ["https://our-jira.my-org.de", "https://my-org.atlassian.net"])
+
+@pytest.mark.parametrize(
+    "url_prefix", ["https://our-jira.my-org.de", "https://my-org.atlassian.net"]
+)
 def test_should_label_project(url_prefix: str) -> None:
     # Given:
     url = f"{url_prefix}/browse/FANCY"
@@ -14,7 +17,10 @@ def test_should_label_project(url_prefix: str) -> None:
     # Then:
     assert_that(label).is_equal_to("FANCY")
 
-@pytest.mark.parametrize("url_prefix", ["https://our-jira.my-org.de", "https://my-org.atlassian.net"])
+
+@pytest.mark.parametrize(
+    "url_prefix", ["https://our-jira.my-org.de", "https://my-org.atlassian.net"]
+)
 def test_should_label_issue(url_prefix: str) -> None:
     # Given:
     url = f"{url_prefix}/browse/FANCY-77"
@@ -25,7 +31,10 @@ def test_should_label_issue(url_prefix: str) -> None:
     # Then:
     assert_that(label).is_equal_to("FANCY-77")
 
-@pytest.mark.parametrize("url_prefix", ["https://our-jira.my-org.de", "https://my-org.atlassian.net"])
+
+@pytest.mark.parametrize(
+    "url_prefix", ["https://our-jira.my-org.de", "https://my-org.atlassian.net"]
+)
 def test_should_label_issue_and_comment(url_prefix: str) -> None:
     # Given:
     url = (
@@ -42,7 +51,10 @@ def test_should_label_issue_and_comment(url_prefix: str) -> None:
     # Then:
     assert_that(label).is_equal_to("FANCY-77.123456")
 
-@pytest.mark.parametrize("url_prefix", ["https://our-jira.my-org.de", "https://my-org.atlassian.net"])
+
+@pytest.mark.parametrize(
+    "url_prefix", ["https://our-jira.my-org.de", "https://my-org.atlassian.net"]
+)
 def test_should_label_issue_and_comment_alternative(url_prefix: str) -> None:
     # Given:
     url = (
@@ -59,7 +71,10 @@ def test_should_label_issue_and_comment_alternative(url_prefix: str) -> None:
     # Then:
     assert_that(label).is_equal_to("FANCY-77.123456")
 
-@pytest.mark.parametrize("url_prefix", ["https://our-jira.my-org.de", "https://my-org.atlassian.net"])
+
+@pytest.mark.parametrize(
+    "url_prefix", ["https://our-jira.my-org.de", "https://my-org.atlassian.net"]
+)
 def test_should_label_servicedesk_issue(url_prefix: str) -> None:
     # https://our-jira.my-org.de/servicedesk/customer/portal/77/SUPPORT-123
     # Given:

--- a/test/test_jira.py
+++ b/test/test_jira.py
@@ -4,9 +4,17 @@ from assertpy import assert_that
 from label_for_url import determine_label
 
 
-@pytest.mark.parametrize(
-    "url_prefix", ["https://our-jira.my-org.de", "https://my-org.atlassian.net"]
+@pytest.fixture(
+    params=[
+        "https://our-jira.my-org.de",
+        "https://my-org.atlassian.net",
+    ]
 )
+def url_prefix(request: any) -> str:
+    print(type(request))
+    return request.param
+
+
 def test_should_label_project(url_prefix: str) -> None:
     # Given:
     url = f"{url_prefix}/browse/FANCY"
@@ -18,9 +26,6 @@ def test_should_label_project(url_prefix: str) -> None:
     assert_that(label).is_equal_to("FANCY")
 
 
-@pytest.mark.parametrize(
-    "url_prefix", ["https://our-jira.my-org.de", "https://my-org.atlassian.net"]
-)
 def test_should_label_issue(url_prefix: str) -> None:
     # Given:
     url = f"{url_prefix}/browse/FANCY-77"
@@ -32,9 +37,6 @@ def test_should_label_issue(url_prefix: str) -> None:
     assert_that(label).is_equal_to("FANCY-77")
 
 
-@pytest.mark.parametrize(
-    "url_prefix", ["https://our-jira.my-org.de", "https://my-org.atlassian.net"]
-)
 def test_should_label_issue_and_comment(url_prefix: str) -> None:
     # Given:
     url = (
@@ -52,9 +54,6 @@ def test_should_label_issue_and_comment(url_prefix: str) -> None:
     assert_that(label).is_equal_to("FANCY-77.123456")
 
 
-@pytest.mark.parametrize(
-    "url_prefix", ["https://our-jira.my-org.de", "https://my-org.atlassian.net"]
-)
 def test_should_label_issue_and_comment_alternative(url_prefix: str) -> None:
     # Given:
     url = (
@@ -72,11 +71,7 @@ def test_should_label_issue_and_comment_alternative(url_prefix: str) -> None:
     assert_that(label).is_equal_to("FANCY-77.123456")
 
 
-@pytest.mark.parametrize(
-    "url_prefix", ["https://our-jira.my-org.de", "https://my-org.atlassian.net"]
-)
 def test_should_label_servicedesk_issue(url_prefix: str) -> None:
-    # https://our-jira.my-org.de/servicedesk/customer/portal/77/SUPPORT-123
     # Given:
     url = f"{url_prefix}/servicedesk/customer/portal/77/SUPPORT-123"
 

--- a/test/test_jira.py
+++ b/test/test_jira.py
@@ -1,11 +1,12 @@
+import pytest
 from assertpy import assert_that
 
 from label_for_url import determine_label
 
-
-def test_should_label_project() -> None:
+@pytest.mark.parametrize("url_prefix", ["https://our-jira.my-org.de", "https://my-org.atlassian.net"])
+def test_should_label_project(url_prefix: str) -> None:
     # Given:
-    url = "https://our-jira.my-org.de/browse/FANCY"
+    url = f"{url_prefix}/browse/FANCY"
 
     # When:
     label = determine_label(url)
@@ -13,10 +14,10 @@ def test_should_label_project() -> None:
     # Then:
     assert_that(label).is_equal_to("FANCY")
 
-
-def test_should_label_issue() -> None:
+@pytest.mark.parametrize("url_prefix", ["https://our-jira.my-org.de", "https://my-org.atlassian.net"])
+def test_should_label_issue(url_prefix: str) -> None:
     # Given:
-    url = "https://our-jira.my-org.de/browse/FANCY-77"
+    url = f"{url_prefix}/browse/FANCY-77"
 
     # When:
     label = determine_label(url)
@@ -24,11 +25,11 @@ def test_should_label_issue() -> None:
     # Then:
     assert_that(label).is_equal_to("FANCY-77")
 
-
-def test_should_label_issue_and_comment() -> None:
+@pytest.mark.parametrize("url_prefix", ["https://our-jira.my-org.de", "https://my-org.atlassian.net"])
+def test_should_label_issue_and_comment(url_prefix: str) -> None:
     # Given:
     url = (
-        "https://our-jira.my-org.de/browse/FANCY-77"
+        f"{url_prefix}/browse/FANCY-77"
         "?focusedCommentId=123456"
         "&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel"
         "#comment-123456"
@@ -41,11 +42,11 @@ def test_should_label_issue_and_comment() -> None:
     # Then:
     assert_that(label).is_equal_to("FANCY-77.123456")
 
-
-def test_should_label_issue_and_comment_alternative() -> None:
+@pytest.mark.parametrize("url_prefix", ["https://our-jira.my-org.de", "https://my-org.atlassian.net"])
+def test_should_label_issue_and_comment_alternative(url_prefix: str) -> None:
     # Given:
     url = (
-        "https://our-jira.my-org.de/browse/FANCY-77"
+        f"{url_prefix}/browse/FANCY-77"
         "?focusedId=123456"
         "&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel"
         "#comment-123456"
@@ -58,11 +59,11 @@ def test_should_label_issue_and_comment_alternative() -> None:
     # Then:
     assert_that(label).is_equal_to("FANCY-77.123456")
 
-
-def test_should_label_servicedesk_issue() -> None:
+@pytest.mark.parametrize("url_prefix", ["https://our-jira.my-org.de", "https://my-org.atlassian.net"])
+def test_should_label_servicedesk_issue(url_prefix: str) -> None:
     # https://our-jira.my-org.de/servicedesk/customer/portal/77/SUPPORT-123
     # Given:
-    url = "https://our-jira.my-org.de/servicedesk/customer/portal/77/SUPPORT-123"
+    url = f"{url_prefix}/servicedesk/customer/portal/77/SUPPORT-123"
 
     # When:
     label = determine_label(url)


### PR DESCRIPTION
Jira & Confluence Cloud URLs have a different schema than on-prem instances.